### PR TITLE
Experimental native support for Amlogic's proprietary eMMC partition table

### DIFF
--- a/Documentation/block/amlogic-partition.rst
+++ b/Documentation/block/amlogic-partition.rst
@@ -1,0 +1,25 @@
+==========================================
+Amlogic proprietary eMMC partition parsing
+==========================================
+
+Available kernel command line options:
+
+apt_checksum (bool):
+	decides whether the table should be checked with Amlogic's
+	checksum algorithm to decide if it's a valid table
+
+	any value other than 0 enables the checksum (default), this
+	should be OK for tables you didn't touch or have modified
+	with ampart as it will update the checksum automatically
+
+	0 disables the checksum, which is only recommended if you
+	modify the table by hand
+
+apt_blkdevs (list of <blkdev-id>):
+	a list of block devices that the table should be parsed on,
+	seperated by ',', if kept empty every block device could be
+	used
+
+	default value: (empty), all block devices could be parsed
+
+	suggested value: mmcblk2, so only eMMC will be parsed

--- a/block/partitions/Kconfig
+++ b/block/partitions/Kconfig
@@ -270,4 +270,16 @@ config CMDLINE_PARTITION
 	  Say Y here if you want to read the partition table from bootargs.
 	  The format for the command line is just like mtdparts.
 
+config AMLOGIC_PARTITION
+	bool "Amlogic proprietary partition support" if PARTITION_ADVANCED
+	help
+	  Say Y here if you want to read Amlogic's proprietary partition
+	  table.
+	  The support is implemented mainly with 7Ji's reverse-engineering
+	  of this partition format on several devices with results available
+	  in the ampart project.
+	  The technical details could have some differences from Amlogic's
+	  own impementation.
+	  Otherwise, say N.
+
 endmenu

--- a/block/partitions/Makefile
+++ b/block/partitions/Makefile
@@ -20,3 +20,4 @@ obj-$(CONFIG_IBM_PARTITION) += ibm.o
 obj-$(CONFIG_EFI_PARTITION) += efi.o
 obj-$(CONFIG_KARMA_PARTITION) += karma.o
 obj-$(CONFIG_SYSV68_PARTITION) += sysv68.o
+obj-$(CONFIG_AMLOGIC_PARTITION) += amlogic.o

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -101,13 +101,13 @@ bool amlogic_is_partition_valid(struct amlogic_partition *part) {
 	offset_raw = le64_to_cpu(part->offset);
 	offset_round = offset_raw >> 9 << 9;
 	if (offset_raw != offset_round) {
-		pr_warn("apt partition's offset is not multiple of 512: %lx\n", offset_raw);
+		pr_warn("apt partition's offset is not multiple of 512: %llx\n", offset_raw);
 		return false;
 	}
 	size_raw = le64_to_cpu(part->size);
 	size_round = size_raw >> 9 << 9;
 	if (size_raw != size_round) {
-		pr_warn("apt partition's size is not multiple of 512: %lx\n", size_raw);
+		pr_warn("apt partition's size is not multiple of 512: %llx\n", size_raw);
 		return false;
 	}
 	return true;
@@ -203,7 +203,7 @@ bool amlogic_should_parse_block(struct parsed_partitions *state) {
  *
  */
 int amlogic_partition(struct parsed_partitions *state){
-	sector_t disk_sector;
+	sector_t disk_sectors;
 	sector_t disk_size;
 	struct amlogic_table apt = {0};
 

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -260,9 +260,9 @@ int amlogic_partition(struct parsed_partitions *state){
 			size -= diff;
 		}
 
-		put_partition(state, i, offset, size);
+		put_partition(state, i + 1, offset, size);
 
-		info = &state->parts[i].info;
+		info = &state->parts[i + 1].info;
 		name_min = min_t(size_t, sizeof info->volname, sizeof part->name);
 		strncpy(info->volname, part->name, name_min);
 		info->volname[name_min] = '\0';
@@ -270,7 +270,7 @@ int amlogic_partition(struct parsed_partitions *state){
 		snprintf(tmp, sizeof(tmp), "(%s)", info->volname);
 		strlcat(state->pp_buf, tmp, PAGE_SIZE);
 
-		state->parts[i].has_info = true;
+		state->parts[i + 1].has_info = true;
 	}
 
 	strlcat(state->pp_buf, "\n", PAGE_SIZE);

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -64,10 +64,6 @@ static int __init apt_checksum_setup(char *s) {
 }
 __setup("apt_checksum", apt_checksum_setup);
 
-int amlogic_is_partition_name_char_valid(char c) {
-	
-}
-
 bool amlogic_is_partition_name_valid(char *name) {
 	for (u8 i = 0; i < 16; ++i) {
 		switch (name[i]) {

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -206,7 +206,7 @@ int amlogic_partition(struct parsed_partitions *state){
 	sector_t disk_sectors;
 	sector_t disk_size;
 	struct amlogic_table *apt;
-	u8 apt_cache[(sizeof *apt >> 9) + 1 << 9] = {0};
+	u8 apt_cache[((sizeof *apt >> 9) + 1) << 9] = {0};
 
 	if (!amlogic_should_parse_block(state)) {
 		return 0;

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -165,8 +165,8 @@ __setup("apt_blkdevs", apt_blkdevs_setup);
 bool amlogic_should_parse_block(struct parsed_partitions *state) {
 	char *blkdev;
 	if (!apt_blkdevs) {
-		pr_warn("apt_blkdevs is not set, module not properly loaded, no operation for safefy\n");
-		return false;
+		pr_warn("apt_blkdevs is not set, all blocks should be parsed\n");
+		return true;
 	}
 	if (!apt_blkdevs[0]) {
 		pr_warn("apt_blkdevs is empty, all block devices will be parsed\n");

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -174,11 +174,15 @@ bool amlogic_should_parse_block(struct parsed_partitions *state) {
 	}
 	/* apt_blkdevs set and not empty, only parse block if its in the list */
 	blkdev = apt_blkdevs;
-	for (char *c = apt_blkdevs; *c; ++c) {
+	for (char *c = apt_blkdevs;; ++c) {
 		switch (*c) {
 			case ',':
 			case '\0':
-				if (!strncmp(blkdev, state->disk->disk_name, c - blkdev)) {
+				if (strncmp(blkdev, state->disk->disk_name, c - blkdev)) {
+					if (*c == '\0') {
+						return false;
+					}
+				} else {
 					return true;
 				}
 				blkdev = c + 1;

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -242,15 +242,15 @@ int amlogic_partition(struct parsed_partitions *state){
 		size_t name_min;
 		char tmp[sizeof(info->volname) + 4];
 		if (offset > disk_sectors) {
+			pr_warn("apt partition %s's offset is larger than disk size (sectors 0x%llx > 0x%llx), shifting its offset to disk end\n", part->name, offset, disk_sectors);
 			offset = disk_sectors;
-			pr_warn("apt partition %s's offset is larger than disk size (sectors %llx > %llx), shifting its offset to disk end\n", part->name, offset, disk_sectors);
 		}
 		
 		end = offset + size;
 
 		if (end > disk_sectors) {
 			u64 diff = end - disk_sectors;
-			pr_warn("apt partition %s' size is too large and it exceeds the disk size (sectors end %llx > %llx), shrinking its size by %llx sectors\n", part->name, end, disk_sectors, diff);
+			pr_warn("apt partition %s's size is too large and it exceeds the disk size (sectors end 0x%llx > 0x%llx), shrinking its size by 0x%llx sectors\n", part->name, end, disk_sectors, diff);
 			size -= diff;
 		}
 

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -62,7 +62,7 @@ static int __init apt_checksum_setup(char *s) {
 	}
 	return 1;
 }
-__setup("apt_checksum", apt_checksum_setup);
+__setup("apt_checksum=", apt_checksum_setup);
 
 bool amlogic_is_partition_name_valid(char *name) {
 	char safe_name[19];
@@ -160,7 +160,7 @@ static int __init apt_blkdevs_setup(char *s) {
 	apt_blkdevs = s;
 	return 1;
 }
-__setup("apt_blkdevs", apt_blkdevs_setup);
+__setup("apt_blkdevs=", apt_blkdevs_setup);
 
 bool amlogic_should_parse_block(struct parsed_partitions *state) {
 	char *blkdev;

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -243,14 +243,14 @@ int amlogic_partition(struct parsed_partitions *state){
 		char tmp[sizeof(info->volname) + 4];
 		if (offset > disk_sectors) {
 			offset = disk_sectors;
-			pr_warn("apt partition %s's offset is larger than disk size (sectors %lx > %x), shifting its offset to disk end\n", part->name, offset, disk_sectors);
+			pr_warn("apt partition %s's offset is larger than disk size (sectors %llx > %llx), shifting its offset to disk end\n", part->name, offset, disk_sectors);
 		}
 		
 		end = offset + size;
 
 		if (end > disk_sectors) {
 			u64 diff = end - disk_sectors;
-			pr_warn("apt partition %s' size is too large and it exceeds the disk size (sectors end %lx > %lx), shrinking its size by %lx sectors\n", part->name, end, disk_sectors, diff);
+			pr_warn("apt partition %s' size is too large and it exceeds the disk size (sectors end %llx > %llx), shrinking its size by %llx sectors\n", part->name, end, disk_sectors, diff);
 			size -= diff;
 		}
 

--- a/block/partitions/amlogic.c
+++ b/block/partitions/amlogic.c
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2023 Guoxin "7Ji" Pu
+ * Author: Pu Guoxin <pugokushin@gmail.com>
+ *
+ * Read Amlogic's proprietary eMMC partition table that is mainly
+ * used on the eMMC on TV boxes running Android with their SoCs.
+ * 
+ * The usage is not limited to eMMC but can be limited with kernel
+ * commandline.
+ *
+ * For further information, see "Documentation/block/amlogic-partition.rst"
+ *
+ */
+
+#include "check.h"
+
+#define APT_PART_NAME_MAXLEN	15
+#define APT_MAX_PARTS			32
+#define APT_MAGIC_STRING		"MPT"
+#define APT_MAGIC_LE32			(__le32)0x0054504DU
+#define APT_VERSION_STRING		"01.00.00"
+
+struct amlogic_header {
+	__le32 magic;
+	char version[12];
+	__le32 count;
+	__le32 checksum;
+} __packed;
+
+struct amlogic_partition {
+	char name[16];
+	__le64 size;
+	__le64 offset;
+	__le32 mask_flags;
+	u32 padding;
+} __packed;
+
+struct amlogic_table {
+	struct amlogic_header header;
+	struct amlogic_partition parts[APT_MAX_PARTS];
+} __packed;
+	
+
+u32 amlogic_checksum(struct amlogic_table *apt) {
+	u32 checksum = 0;
+	u32 *p;
+	for (u32 i = 0; i < le32_to_cpu(apt->header.count); ++i) {
+		p = (u32 *)apt->parts;
+		for (u32 j = sizeof *apt->parts / sizeof *p; j > 0; --j) {
+			checksum += le32_to_cpu(*p++);
+		}
+	}
+	return checksum;
+}
+
+static bool apt_checksum = true;
+static int __init apt_checksum_setup(char *s) {
+	if (s && s[0] == '0' && s[1] == '\0') {
+		pr_warn("apt_checksum is disabled\n");
+		apt_checksum = false;
+	}
+	return 1;
+}
+__setup("apt_checksum", apt_checksum_setup);
+
+int amlogic_is_partition_name_char_valid(char c) {
+	
+}
+
+bool amlogic_is_partition_name_valid(char *name) {
+	for (u8 i = 0; i < 16; ++i) {
+		switch (name[i]) {
+			case 'a'...'z':
+			case '_':
+				if (i == 15) {
+					char safe_name[19];
+					strncpy(safe_name, name, 15);
+					strncpy(safe_name + 15, "...", 3);
+					pr_warn("partition name not ended properly: %s\n", safe_name);
+					return false;
+				} else {
+					break;
+				}
+			case '\0':
+				if (i == 0) {
+					pr_warn("partition name empty, which is illegal\n");
+					return false;
+				} else {
+					return true;
+				}
+			default:
+				pr_warn("illegal character in apt partition name: %c, allowed for now, MAYBE FORBIDDEN IN THE FUTURE\n", name[i]);
+				break;
+		}
+	}
+}
+
+bool amlogic_is_partition_valid(struct amlogic_partition *part) {
+	if (!amlogic_is_partition_name_valid(part->name)) {
+		return false;
+	}
+	/* They could be not  */
+	u64 offset_raw = le64_to_cpu(part->offset);
+	u64 offset_round = offset_raw >> 9 << 9;
+	if (offset_raw != offset_round) {
+		pr_warn("apt partition's offset is not multiple of 512: %lx\n");
+		return false;
+	}
+	u64 size_raw = le64_to_cpu(part->size);
+	u64 size_actual = size_raw >> 9 << 9;
+	if (size_raw != size_actual) {
+		pr_warn("apt partition's size is not multiple of 512: %lx\n");
+		return false;
+	}
+}
+
+bool amlogic_is_valid(struct amlogic_table *apt) {
+	if (!apt) {
+		pr_warn("apt not allocated properly\n");
+		return false;
+	}
+	if (apt->header.magic != APT_MAGIC_LE32) {
+		pr_warn("apt header magic not right: %x != %x\n", apt->header.magic, APT_MAGIC_LE32);
+		return false;
+	}
+	if (strncmp(apt->header.version, APT_VERSION_STRING, strlen(APT_VERSION_STRING))) {
+		char safe_version[15] = "";
+		strncpy(safe_version, apt->header.version, 11);
+		if (safe_version[11]) {
+			strncpy(safe_version + 11, "...", 3);
+		}
+		pr_warn("apt header version not right: %s != %s\n", safe_version, APT_VERSION_STRING);
+		return false;
+	}
+	if (!apt->header.count) {
+		pr_warn("apt header entries count is 0, skipped\n");
+		return false;
+	}
+	if (le32_to_cpu(apt->header.count) > APT_MAX_PARTS) {
+		pr_warn("apt entries overflow: %u > %u\n", le32_to_cpu(apt->header.count), APT_MAX_PARTS);
+		return false;
+	}
+	u32 checksum = amlogic_checksum(apt);
+	if (apt_checksum && checksum != le32_to_cpu(apt->header.checksum)) {
+		pr_warn("apt checksum mismatch: calculated %x != recorded %x. (This check can be turned off by setting apt_checksum=0)\n", checksum, le32_to_cpu(apt->header.checksum));
+		return false;
+	}
+	for (u32 i = 0; i < le32_to_cpu(apt->header.count); i++) {
+		if (!amlogic_is_partition_valid(apt->parts + i)) {
+			pr_warn("apt partition entry %u invalid\n", i);
+			return false;
+		}
+	}
+	return true;
+}
+
+static char *apt_blkdevs;
+
+static int __init apt_blkdevs_setup(char *s) {
+	apt_blkdevs = s;
+	return 1;
+}
+__setup("apt_blkdevs", apt_blkdevs_setup);
+
+bool amlogic_should_parse_block(struct parsed_partitions *state) {
+	if (!apt_blkdevs) {
+		pr_warn("apt_blkdevs is not set, module not properly loaded, no operation for safefy\n");
+		return false;
+	}
+	if (!apt_blkdevs[0]) {
+		pr_warn("apt_blkdevs is empty, all block devices will be parsed\n");
+		return true;
+	}
+	/* apt_blkdevs set and not empty, only parse block if its in the list */
+	char *blkdev = apt_blkdevs;
+	for (char *c = apt_blkdevs; *c; ++c) {
+		switch (*c) {
+			case ',':
+			case '\0':
+				if (!strncmp(blkdev, state->disk->disk_name, c - blkdev)) {
+					return true;
+				}
+				blkdev = c + 1;
+				/* end of a blkdev definition */
+				break;
+			default:
+				break;
+		}
+
+	}
+	return false;
+}
+
+/**
+ * amlogic_partition - scan for Amlogic proprietary partitions
+ * @state: disk parsed partitions
+ * 
+ * Returns:
+ * -1 if unable to read the partition table
+ *  0 if this isn't our partition table
+ *  1 if successful
+ *
+ */
+int amlogic_partition(struct parsed_partitions *state)
+{
+	if (!amlogic_should_parse_block(state)) {
+		return 0;
+	}
+
+	sector_t disk_sectors = get_capacity(state->disk);
+	if (disk_sectors < 0x12003) {
+		return 0;
+	}
+	sector_t disk_size = disk_sectors << 9;
+
+	struct amlogic_table apt = {0};
+	 
+	for (sector_t i = 0; i < 3; ++i) {
+		Sector sect;
+		u8 *data = read_part_sector(state, 0x12000 + i, &sect);
+		if (!data) {
+			return -1;
+		}
+		memcpy((u8 *)(&apt) + 512 * i, data, 512);
+		put_dev_sector(sect);
+	}
+
+	if (!amlogic_is_valid(&apt)) {
+		return 0;
+	}
+
+	pr_debug("Amlogic partition table is valid, now parsing it\n");
+
+	for (u32 i = 0; i < le32_to_cpu(apt.header.count) && i < state->limit-1; i++) {
+		struct amlogic_partition *part = apt.parts + i;
+		u64 offset = le64_to_cpu(part->offset) >> 9;
+		u64 size = le64_to_cpu(part->size) >> 9;
+		if (offset > disk_sectors) {
+			offset = disk_sectors;
+			pr_warn("apt partition %s's offset is larger than disk size (sectors %lx > %x), shifting its offset to disk end\n", part->name, offset, disk_sectors);
+		}
+		
+		u64 end = offset + size;
+
+		if (end > disk_sectors) {
+			u64 diff = end - disk_sectors;
+			pr_warn("apt partition %s' size is too large and it exceeds the disk size (sectors end %lx > %lx), shrinking its size by %lx sectors\n", part->name, end, disk_sectors, diff);
+			size -= diff;
+		}
+
+		put_partition(state, i, offset, size);
+
+		struct partition_meta_info *info = &state->parts[i].info;
+		size_t name_min = min_t(size_t, sizeof info->volname, sizeof part->name);
+		strncpy(info->volname, part->name, name_min);
+		info->volname[name_min] = '\0';
+
+		char tmp[sizeof(info->volname) + 4];
+		snprintf(tmp, sizeof(tmp), "(%s)", info->volname);
+		strlcat(state->pp_buf, tmp, PAGE_SIZE);
+
+		state->parts[i].has_info = true;
+	}
+
+	strlcat(state->pp_buf, "\n", PAGE_SIZE);
+	return 1;
+}

--- a/block/partitions/check.h
+++ b/block/partitions/check.h
@@ -67,3 +67,4 @@ int sgi_partition(struct parsed_partitions *state);
 int sun_partition(struct parsed_partitions *state);
 int sysv68_partition(struct parsed_partitions *state);
 int ultrix_partition(struct parsed_partitions *state);
+int amlogic_partition(struct parsed_partitions *state);

--- a/block/partitions/core.c
+++ b/block/partitions/core.c
@@ -82,6 +82,9 @@ static int (*check_part[])(struct parsed_partitions *) = {
 #ifdef CONFIG_SYSV68_PARTITION
 	sysv68_partition,
 #endif
+#ifdef CONFIG_AMLOGIC_PARTITION
+	amlogic_partition,
+#endif
 	NULL
 };
 


### PR DESCRIPTION
This adds experimental support for Amlogic's proprietary eMMC partition table to the kernel, based on my reverse engineering results previously only available in [ampart]

The support is added in the kernel's block subsystem, not in the MMC driver, so it can now identify such partition layout on **any block device**, e.g.:

 - mmc2, our old friend eMMC, of course it'll be supported

	_dmesg output_
	```
	[    1.392239] mmc2: new DDR MMC card at address 0001
	[    1.395820] mmcblk2: mmc2:0001 008G30 7.28 GiB 
	[    1.402019]  mmcblk2: p0(bootloader) p1(reserved) p2(cache) p3(env) p4(logo) p5(recovery) p6(rsv) p7(tee) p8(crypt) p9(misc) p10(instaboot) p11(boot) p12(system) p13(params) p14(data)
	[    1.418000] mmcblk2boot0: mmc2:0001 008G30 4.00 MiB 
	[    1.422305] mmcblk2boot1: mmc2:0001 008G30 4.00 MiB 
	[    1.426812] mmcblk2rpmb: mmc2:0001 008G30 4.00 MiB, chardev (244:0)
	```
	_lsblk output_
	```
	mmcblk2      179:32   0   7.3G  0 disk 
	├─mmcblk2p1  179:33   0    64M  0 part 
	├─mmcblk2p2  179:34   0   512M  0 part 
	├─mmcblk2p3  179:35   0     8M  0 part 
	├─mmcblk2p4  179:36   0    32M  0 part 
	├─mmcblk2p5  179:37   0    32M  0 part 
	├─mmcblk2p6  179:38   0     8M  0 part 
	├─mmcblk2p7  179:39   0     8M  0 part 
	├─mmcblk2p8  179:40   0    32M  0 part 
	├─mmcblk2p9  179:41   0    32M  0 part 
	├─mmcblk2p10 179:42   0   512M  0 part 
	├─mmcblk2p11 179:43   0    32M  0 part 
	├─mmcblk2p12 179:44   0     1G  0 part 
	├─mmcblk2p13 179:45   0    64M  0 part 
	└─mmcblk2p14 179:46   0   4.8G  0 part
	```
  - loop0, useful for analyzing dumps
	
	_dmesg output_
	```
	[  122.601800] loop0: detected capacity change from 0 to 268435456
	[  122.602525]  loop0: p0(bootloader) p1(reserved) p2(cache) p3(env) p4(logo) p5(recovery) p6(misc) p7(dtbo) p8(cri_data) p9(param) p10(boot) p11(rsv) p12(metadata) p13(vbmeta) p14(tee) p15(vendor) p16(odm) p17(system) p18(product) p19(data)
	```
	_lsblk output_
	```
	loop0          7:0    0   128G  0 loop 
	├─loop0p1    259:0    0    64M  0 part 
	├─loop0p2    259:1    0   1.1G  0 part 
	├─loop0p3    259:2    0     8M  0 part 
	├─loop0p4    259:3    0     8M  0 part 
	├─loop0p5    259:4    0    24M  0 part 
	├─loop0p6    259:5    0     8M  0 part 
	├─loop0p7    259:6    0     8M  0 part 
	├─loop0p8    259:7    0     8M  0 part 
	├─loop0p9    259:8    0    16M  0 part 
	├─loop0p10   259:9    0    16M  0 part 
	├─loop0p11   259:10   0    16M  0 part 
	├─loop0p12   259:11   0    16M  0 part 
	├─loop0p13   259:12   0     2M  0 part 
	├─loop0p14   259:13   0    32M  0 part 
	├─loop0p15   259:14   0   320M  0 part 
	├─loop0p16   259:15   0   128M  0 part 
	├─loop0p17   259:16   0   1.8G  0 part 
	├─loop0p18   259:17   0   128M  0 part 
	└─loop0p19   259:18   0 112.6G  0 part
	```

It will also send udev events with correct block names so the following udev rule could be used to create symlinks under `/dev/block` with correponding name for easy access:
```
SUBSYSTEM=="block", KERNEL=="mmcblk2p*", ENV{DEVTYPE}=="partition", SYMLINK+="block/$env{PARTNAME}"
```

Symlinks under `/dev/block` with the above udev rules:
```
# ls -al /dev/block/
total 0
drwxr-xr-x  2 root root  740 Feb 18 08:41 .
drwxr-xr-x 16 root root 3500 Feb 23 23:35 ..
lrwxrwxrwx  1 root root   10 Feb 18 08:41 179:0 -> ../mmcblk1
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:1 -> ../mmcblk1p1
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:2 -> ../mmcblk1p2
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:3 -> ../mmcblk1p3
lrwxrwxrwx  1 root root   10 Feb 18 08:41 179:32 -> ../mmcblk2
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:33 -> ../mmcblk2p1
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:34 -> ../mmcblk2p2
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:35 -> ../mmcblk2p3
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:36 -> ../mmcblk2p4
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:37 -> ../mmcblk2p5
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:38 -> ../mmcblk2p6
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:39 -> ../mmcblk2p7
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:40 -> ../mmcblk2p8
lrwxrwxrwx  1 root root   12 Feb 18 08:41 179:41 -> ../mmcblk2p9
lrwxrwxrwx  1 root root   13 Feb 18 08:41 179:42 -> ../mmcblk2p10
lrwxrwxrwx  1 root root   13 Feb 18 08:41 179:43 -> ../mmcblk2p11
lrwxrwxrwx  1 root root   13 Feb 18 08:41 179:44 -> ../mmcblk2p12
lrwxrwxrwx  1 root root   13 Feb 18 08:41 179:45 -> ../mmcblk2p13
lrwxrwxrwx  1 root root   13 Feb 18 08:41 179:46 -> ../mmcblk2p14
lrwxrwxrwx  1 root root   15 Feb 18 08:41 179:64 -> ../mmcblk2boot0
lrwxrwxrwx  1 root root   15 Feb 18 08:41 179:96 -> ../mmcblk2boot1
lrwxrwxrwx  1 root root   13 Feb 18 08:41 boot -> ../mmcblk2p11
lrwxrwxrwx  1 root root   12 Feb 18 08:41 cache -> ../mmcblk2p2
lrwxrwxrwx  1 root root   12 Feb 18 08:41 crypt -> ../mmcblk2p8
lrwxrwxrwx  1 root root   13 Feb 18 08:41 data -> ../mmcblk2p14
lrwxrwxrwx  1 root root   12 Feb 18 08:41 env -> ../mmcblk2p3
lrwxrwxrwx  1 root root   13 Feb 18 08:41 instaboot -> ../mmcblk2p10
lrwxrwxrwx  1 root root   12 Feb 18 08:41 logo -> ../mmcblk2p4
lrwxrwxrwx  1 root root   12 Feb 18 08:41 misc -> ../mmcblk2p9
lrwxrwxrwx  1 root root   13 Feb 18 08:41 params -> ../mmcblk2p13
lrwxrwxrwx  1 root root   12 Feb 18 08:41 recovery -> ../mmcblk2p5
lrwxrwxrwx  1 root root   12 Feb 18 08:41 reserved -> ../mmcblk2p1
lrwxrwxrwx  1 root root   12 Feb 18 08:41 rsv -> ../mmcblk2p6
lrwxrwxrwx  1 root root   13 Feb 18 08:41 system -> ../mmcblk2p12
lrwxrwxrwx  1 root root   12 Feb 18 08:41 tee -> ../mmcblk2p7
```

### Priority
Such partitions will be parsed **after** all other existing partition types including MBR and GPT. So it will only be recognized if there is no MBR or GPT. This is also the way Amlogic handles it.

### Userspace
My project [ampart] provides a tool that can modify such partition table in userspace

### Build

The support could be built with the following config:
```
CONFIG_AMLOGIC_PARTITION=y
```

### Configuration

The following kernel options are available to set its behaviour:
 - `apt_checksum`
   - if set to any value other than 0 (even empty), will enable the checksum calculation, recommended for stock layout and layouts adjusted by [ampart] as it will automatically update the checksum. (**default**)
   - if set to 0, will disable the checksum calculation, recommended if you've adjusted the layout with some manual hex-editting
   - example: `apt_checksum=0`

 - `apt_blkdevs`
   - a comma (`,`) seperated list of block device names (e.g. `mmcblk2`, `loop0`, etc)
   - if unset or empty, all block devices will be parsed (**default**)
   - if set, only blocked devices listed will be parsed
   - example: `apt_blkdevs=mmcblk2,loop0`

[ampart]: https://github.com/7Ji/ampart
