### PR TITLE
arm64: dts: amlogic: add openvfd overlay

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlay/Makefile
+++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
@@ -2,6 +2,7 @@
 dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-i2cA.dtbo \
 	meson-i2cB.dtbo \
+	meson-openvfd.dtbo \
 	meson-uartA.dtbo \
 	meson-uartC.dtbo \
 	meson-w1-gpio.dtbo \

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-openvfd.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-openvfd.dts
@@ -1,0 +1,10 @@
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	openvfd: openvfd {
+		compatible = "open,vfd";
+		dev_name = "openvfd";
+		status = "okay";
+	};
+};


### PR DESCRIPTION
This makes it possible to hotly switch on/off the openvfd function without having to go through all dt source to add/remove the openvfd node.

Using a mainline u-boot the overlay can be easily enabled/disabled by adding/ removing a line like the following in distro_boot configuration (e.g. `/boot/extlinux/extlinux.conf`):

```
FDTOVERLAYS /dtbs/linux-aarch64-flippy/amlogic/overlay/meson-openvfd.dtbo
```