### PR TITLE
Support for HK1 BOX system led (not LED display)

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
@@ -82,6 +82,17 @@
 		vin-supply = <&ao_5v>;
 		regulator-always-on;
 	};
+	
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+		sys_led {
+			label = "sys_led";
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+			linux,default-trigger = "default-on";
+		};
+	};
 };
 
 &vddcpu {


### PR DESCRIPTION
为HK1 Box 的蓝色系统指示灯（非LED显示屏）添加支持