### PR TITLE
Update rk3399-eaidk-610.dts to fix type-c host mode

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-eaidk-610.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-eaidk-610.dts
@@ -982,7 +982,7 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
-	usb-role-switch;
+	dr_mode = "host";
 
 	port {
 		#address-cells = <1>;


### PR DESCRIPTION
按道理来说，用角色转换应该不会出现问题。但是fusb302这个驱动有点诡异，一定要手动指定工作模式，否则就直接无法初始化type-c控制器